### PR TITLE
feat: #WB-2472, parse old templates as HTML tables

### DIFF
--- a/src/controllers/transformation-controller.ts
+++ b/src/controllers/transformation-controller.ts
@@ -1,6 +1,8 @@
 import { Response } from 'express';
 import { TransformationFormat } from '../models/format.js';
 import { AuthenticatedRequest, ContentTransformerRequest, ContentTransformerResponse } from '../models/transformation-request.js';
+import TableOrTemplate from '../models/TableOrTemplate.js';
+import TableOrTemplateCell from '../models/TableOrTemplateCell.js';
 
 import { generateText } from '@tiptap/core';
 import Link from "@tiptap/extension-link";
@@ -15,7 +17,6 @@ import { Iframe } from '@edifice-tiptap-extensions/extension-iframe';
 import { CustomImage } from '@edifice-tiptap-extensions/extension-image';
 import { Linker } from '@edifice-tiptap-extensions/extension-linker';
 import { MathJax } from '@edifice-tiptap-extensions/extension-mathjax';
-import { TableCell } from '@edifice-tiptap-extensions/extension-table-cell';
 import { Templates } from '@edifice-tiptap-extensions/extension-templates';
 import { Video } from '@edifice-tiptap-extensions/extension-video';
 import { Color } from '@tiptap/extension-color';
@@ -23,7 +24,6 @@ import FontFamily from "@tiptap/extension-font-family";
 import Highlight from "@tiptap/extension-highlight";
 import Subscript from "@tiptap/extension-subscript";
 import Superscript from "@tiptap/extension-superscript";
-import Table from '@tiptap/extension-table';
 import TableHeader from '@tiptap/extension-table-header';
 import TableRow from '@tiptap/extension-table-row';
 import TextAlign from "@tiptap/extension-text-align";
@@ -44,10 +44,10 @@ const EXTENSIONS = [
   Color,
   Subscript,
   Superscript,
-  Table,
+  TableOrTemplate,
   TableRow,
   TableHeader,
-  TableCell,
+  TableOrTemplateCell,
   TextAlign.configure({
     types: ["heading", "paragraph"],
   }),

--- a/src/models/TableOrTemplate.ts
+++ b/src/models/TableOrTemplate.ts
@@ -1,0 +1,67 @@
+import Table from '@tiptap/extension-table';
+
+export default Table.extend({
+  // transformer-only : parse old-format "templates" as tables
+  addAttributes() {
+    return {
+      template: {
+        default: null,
+      }
+    }
+  },
+  parseHTML() {
+    return this.parent?.()?.concat([
+      {
+        tag: 'div.row',
+        getAttrs: (el) => {
+          // Check if columns are present. If not, ignore the template attribute.
+          if (!el || typeof el === "string")
+            return false;
+          const columns = el.querySelectorAll(".column.cell");
+          if (!columns || columns.length <= 0)
+            return false;
+          // Otherwise, determine columns width.
+          const template = [];
+          for (let i = 0; i < columns.length; i++) {
+            const column = columns[i];
+            if (column.classList.contains("image-template")) {
+              template.push("30%");
+              template.push("70%");
+              break;
+            }
+            if (column.classList.contains("three")) {
+              template.push("25%");
+            } else if (column.classList.contains("four")) {
+              template.push("33.33%");
+            } else if (column.classList.contains("six")) {
+              template.push("50%");
+            } else if (column.classList.contains("eight")) {
+              template.push("66.66%");
+            } else if (column.classList.contains("nine")) {
+              template.push("75%");
+            } else {
+              template.push("");
+            }
+          }
+          return {
+            template,
+          }
+        },
+      },
+    ]);
+  },
+  renderHTML(props) {
+    //FIXME This code is too tightened to its parent's implementation
+    const output = this.parent?.(props) as unknown as Array<string | Object | 0>;
+    const columnsWidth: string[] | undefined | null = props.HTMLAttributes["template"];
+    if (!columnsWidth || columnsWidth.length <= 0)
+      return output;
+    const columns = columnsWidth.map((width) => ["col", { width: width }]);
+    return [
+      output[0],
+      output[1],
+      ['colgroup', {}].concat(columns),
+      ['tbody', 0]
+    ] as any;
+  }
+});

--- a/src/models/TableOrTemplateCell.ts
+++ b/src/models/TableOrTemplateCell.ts
@@ -1,0 +1,10 @@
+import { TableCell } from '@edifice-tiptap-extensions/extension-table-cell';
+
+export default TableCell.extend({
+    // transformer-only : parse old-format "cell column" as cells
+    parseHTML() {
+        return this.parent?.()?.concat([
+            { tag: '.cell.column' },
+        ])
+    },
+});


### PR DESCRIPTION
Old templates were based on the grid model from `entcore-css-lib`, for example : 
```
<div class="row">
  <div class="six cell column">A column at 50% width</div>
  <div class="six cell column">Another column at 50% width</div>
</div>
```
- The transformer MUST transform them in a table-based HTML equivalent.
- Fontends SHOULD NOT have knowledge of the old model, and just decode HTML tables as usual.

That's why the transformation is coded right here, in the transformer, by directly extending the `table` and `table-cell` extensions.